### PR TITLE
.gitignore client.properties.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 hashicorp.gpg
 *.tfstate
+client.properties


### PR DESCRIPTION
This file contains secrets when generated - ensure it is gitignore-d.