### PR TITLE
Fixed TF

### DIFF
--- a/terraform-complete/cflt_cloud.tf
+++ b/terraform-complete/cflt_cloud.tf
@@ -231,17 +231,14 @@ resource "confluent_api_key" "env-manager-flink-api-key" {
     api_version = confluent_service_account.app_manager.api_version
     kind        = confluent_service_account.app_manager.kind
   }
-
   managed_resource {
-    id          = "${var.cc_compute_pool_region}"
-    api_version = "fcpm/v2"
-    kind        = "Region"
-
+    id          = data.confluent_flink_region.main.id
+    api_version = data.confluent_flink_region.main.api_version
+    kind        = data.confluent_flink_region.main.kind
     environment {
       id = confluent_environment.cc_handson_env.id
     }
   }
-
   lifecycle {
     prevent_destroy = false
   }

--- a/terraform-complete/cflt_flink_sql.tf
+++ b/terraform-complete/cflt_flink_sql.tf
@@ -36,7 +36,7 @@ resource "confluent_flink_statement" "create_shoe_customers_keyed" {
   principal {
     id = confluent_service_account.app_manager.id
   }
-  statement  = "CREATE TABLE shoe_customers_keyed(customer_id STRING,first_name STRING,last_name STRING,email STRING,PRIMARY KEY (customer_id) NOT ENFORCED) WITH ('kafka.partitions' = '1');"
+  statement  = "CREATE TABLE shoe_customers_keyed(customer_id STRING,first_name STRING,last_name STRING,email STRING,PRIMARY KEY (customer_id) NOT ENFORCED) DISTRIBUTED INTO 1 BUCKETS;"
   properties = {
     "sql.current-catalog"  = confluent_environment.cc_handson_env.display_name
     "sql.current-database" = confluent_kafka_cluster.cc_kafka_cluster.display_name
@@ -77,7 +77,7 @@ resource "confluent_flink_statement" "create_shoe_products_keyed" {
   principal {
     id = confluent_service_account.app_manager.id
   }
-  statement  = "CREATE TABLE shoe_products_keyed(product_id STRING,brand STRING,`model` STRING,sale_price INT,rating DOUBLE,PRIMARY KEY (product_id) NOT ENFORCED) WITH ('kafka.partitions' = '1');"
+  statement  = "CREATE TABLE shoe_products_keyed(product_id STRING,brand STRING,`model` STRING,sale_price INT,rating DOUBLE,PRIMARY KEY (product_id) NOT ENFORCED) DISTRIBUTED INTO 1 BUCKETS;"
   properties = {
     "sql.current-catalog"  = confluent_environment.cc_handson_env.display_name
     "sql.current-database" = confluent_kafka_cluster.cc_kafka_cluster.display_name
@@ -190,7 +190,7 @@ resource "confluent_flink_statement" "create_shoe_order_customer" {
   principal {
     id = confluent_service_account.app_manager.id
   }
-  statement  = "CREATE TABLE shoe_order_customer(order_id INT,product_id STRING,first_name STRING,last_name STRING,email STRING) WITH ('changelog.mode' = 'retract', 'kafka.partitions' = '1');"
+  statement  = "CREATE TABLE shoe_order_customer(order_id INT,product_id STRING,first_name STRING,last_name STRING,email STRING) DISTRIBUTED INTO 1 BUCKETS WITH ('changelog.mode' = 'retract');"
   properties = {
     "sql.current-catalog"  = confluent_environment.cc_handson_env.display_name
     "sql.current-database" = confluent_kafka_cluster.cc_kafka_cluster.display_name
@@ -269,7 +269,7 @@ resource "confluent_flink_statement" "create_shoe_order_customer_product" {
   principal {
     id = confluent_service_account.app_manager.id
   }
-  statement  = "CREATE TABLE shoe_order_customer_product(order_id INT,first_name STRING,last_name STRING,email STRING,brand STRING,`model` STRING,sale_price INT,rating DOUBLE) WITH ('changelog.mode' = 'retract', 'kafka.partitions' = '1');"
+  statement  = "CREATE TABLE shoe_order_customer_product(order_id INT,first_name STRING,last_name STRING,email STRING,brand STRING,`model` STRING,sale_price INT,rating DOUBLE) DISTRIBUTED INTO 1 BUCKETS WITH ('changelog.mode' = 'retract');"
   properties = {
     "sql.current-catalog"  = confluent_environment.cc_handson_env.display_name
     "sql.current-database" = confluent_kafka_cluster.cc_kafka_cluster.display_name
@@ -349,7 +349,7 @@ resource "confluent_flink_statement" "create_shoe_loyalty_levels" {
   principal {
     id = confluent_service_account.app_manager.id
   }
-  statement  = "CREATE TABLE shoe_loyalty_levels(email STRING,total BIGINT,rewards_level STRING,PRIMARY KEY (email) NOT ENFORCED) WITH ('kafka.partitions' = '1');"
+  statement  = "CREATE TABLE shoe_loyalty_levels(email STRING,total BIGINT,rewards_level STRING,PRIMARY KEY (email) NOT ENFORCED) DISTRIBUTED INTO 1 BUCKETS;"
   properties = {
     "sql.current-catalog"  = confluent_environment.cc_handson_env.display_name
     "sql.current-database" = confluent_kafka_cluster.cc_kafka_cluster.display_name
@@ -430,7 +430,7 @@ resource "confluent_flink_statement" "create_shoe_promotions" {
   principal {
     id = confluent_service_account.app_manager.id
   }
-  statement  = "CREATE TABLE shoe_promotions(email STRING,promotion_name STRING,PRIMARY KEY (email) NOT ENFORCED) WITH ('kafka.partitions' = '1');"
+  statement  = "CREATE TABLE shoe_promotions(email STRING,promotion_name STRING,PRIMARY KEY (email) NOT ENFORCED) DISTRIBUTED INTO 1 BUCKETS;"
   properties = {
     "sql.current-catalog"  = confluent_environment.cc_handson_env.display_name
     "sql.current-database" = confluent_kafka_cluster.cc_kafka_cluster.display_name


### PR DESCRIPTION
tf in ./terraform_complete is failing with 

```bash
│ Error: error creating Flink Statement "": 401 Unauthorized: Unauthorized
│ 
│   with confluent_flink_statement.create_shoe_customers_keyed,
│   on cflt_flink_sql.tf line 17, in resource "confluent_flink_statement" "create_shoe_customers_keyed":
│   17: resource "confluent_flink_statement" "create_shoe_customers_keyed" {
```

and 

```bash
│ Error: error waiting for Flink Statement "tf-2025-02-11-153526-4c8e8454-68be-44c9-a7a2-7604f4ee9046" to provision: flink Statement "tf-2025-02-11-153526-4c8e8454-68be-44c9-a7a2-7604f4ee9046" provisioning status is "FAILED": The 'kafka.partitions' option is not supported anymore. Use the DISTRIBUTED INTO n BUCKETS clause instead.
│ 
│   with confluent_flink_statement.create_shoe_customers_keyed,
│   on cflt_flink_sql.tf line 17, in resource "confluent_flink_statement" "create_shoe_customers_keyed":
│   17: resource "confluent_flink_statement" "create_shoe_customers_keyed" {
```

Looks like some outdated code. The PR aims to address both of these issues.